### PR TITLE
use string key for timestamp to fix sorting

### DIFF
--- a/lib/cloudex/cloudinary_api/live.ex
+++ b/lib/cloudex/cloudinary_api/live.ex
@@ -78,7 +78,7 @@ defmodule Cloudex.CloudinaryApi.Live do
 
     data_to_sign = data
       |> Map.delete(:file)
-      |> Map.merge(%{timestamp: (timestamp <> Settings.get(:secret))})
+      |> Map.merge(%{"timestamp" => (timestamp <> Settings.get(:secret))})
 
     signature = data_to_sign
       |> Enum.sort


### PR DESCRIPTION
keys for upload opts (like `"folder"`) need to be binaries. sorting however puts atoms before binaries, so signing did not work in such cases.

```elixir
iex(2)> Enum.sort(%{"folder" => "test", timestamp: 123})
[{:timestamp, 123}, {"folder", "test"}]
iex(3)> Enum.sort(%{"folder" => "test", "timestamp" => 123})
[{"folder", "test"}, {"timestamp", 123}]
```