### PR TITLE
Handle web request errors on upload.

### DIFF
--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -25,7 +25,7 @@ defmodule Cloudex do
     valid_list = Enum.filter(sanitized_list, fn item -> match?({:ok, _}, item) end)
     upload_results = valid_list
       |> Enum.map(fn image -> Task.async(cloudinary_api, :upload, [image]) end)
-      |> Enum.map(&Task.await/1)
+      |> Enum.map(&Task.await(&1, 60_000))
     upload_results ++ invalid_list
   end
 

--- a/lib/cloudex/cloudinary_api/live.ex
+++ b/lib/cloudex/cloudinary_api/live.ex
@@ -52,7 +52,7 @@ defmodule Cloudex.CloudinaryApi.Live do
   end
 
   defp post(body, source) do
-    {:ok, raw_response} = HTTPoison.request(
+    with {:ok, raw_response} <- HTTPoison.request(
       :post,
       "http://api.cloudinary.com/v1_1/#{Settings.get(:cloud_name)}/image/upload",
       body,
@@ -60,9 +60,9 @@ defmodule Cloudex.CloudinaryApi.Live do
         {"Content-Type", "application/x-www-form-urlencoded"},
         {"Accept", "application/json"},
       ]
-    )
-    {:ok, response} = raw_response.body |> Poison.decode
-    response |> handle_response(source)
+    ),
+    {:ok, response} <- Poison.decode(raw_response.body),
+    do: handle_response(response, source)
   end
 
   defp handle_response(%{"error" => %{"message" => error}}, _source) do


### PR DESCRIPTION
Whenever an HTTPoison call failed, it would fail with a match error.
This uses `with` goodness to bubble up request or JSON parsing errors.

I also increased the task timeout on upload to 60 seconds.