### PR TITLE
Handling tags during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The response will be a Cloudex.UploadedImage Struct, or a list of those when you
 You can tag uploaded images with strings:
 
 ```elixir
-Cloudex.upload(["test/assets/test.jpg"], %{tags: ["foo", "bar"]})
+Cloudex.upload(["test/assets/test.jpg"], %{tags: "foo,bar"})
 %Cloudex.UploadedImage{
     bytes: 22659,
     created_at: "2015-11-27T10:02:23Z",

--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ The response will be a Cloudex.UploadedImage Struct, or a list of those when you
 You can tag uploaded images with strings:
 
 ```elixir
+# as array
+Cloudex.upload(["test/assets/test.jpg"], %{tags: ["foo", "bar"]})
+# as comma-separated string
 Cloudex.upload(["test/assets/test.jpg"], %{tags: "foo,bar"})
+
+# result
 %Cloudex.UploadedImage{
     bytes: 22659,
     created_at: "2015-11-27T10:02:23Z",
@@ -102,6 +107,9 @@ Cloudex.upload(["test/assets/test.jpg"], %{tags: "foo,bar"})
     width: 250
 }
 ```
+
+List of additional parameters you can use with `upload/2`:
+http://cloudinary.com/documentation/image_upload_api_reference#upload
 
 ## Cloudinary URL generation
 This package also provides an helper to generate urls from cloudinary given a public id of the image.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ The response will be a Cloudex.UploadedImage Struct, or a list of those when you
 }
 ```
 
+You can tag uploaded images with strings:
+
+```elixir
+Cloudex.upload(["test/assets/test.jpg"], %{tags: ["foo", "bar"]})
+%Cloudex.UploadedImage{
+    bytes: 22659,
+    created_at: "2015-11-27T10:02:23Z",
+    etag: "dbb5764565c1b77ff049d20fcfd1d41d",
+    format: "jpg",
+    height: 167,
+    original_filename: "test",
+    public_id: "i2nruesgu4om3w9mtk1z",
+    resource_type: "image",
+    secure_url: "https://d1vibqt9pdnk2f.cloudfront.net/image/upload/v1448618543/i2nruesgu4om3w9mtk1z.jpg",
+    signature: "77b447746476c82bb4921fdea62a9227c584974b",
+    source: "http://example.org/test.jpg",
+    tags: ["foo", "bar"],
+    type: "upload",
+    url: "http://images.cloudassets.mobi/image/upload/v1448618543/i2nruesgu4om3w9mtk1z.jpg",
+    version: 1448618543,
+    width: 250
+}
+```
+
 ## Cloudinary URL generation
 This package also provides an helper to generate urls from cloudinary given a public id of the image.
 As a second argument you can pass in options to transform your image according via cloudinary.

--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -17,14 +17,14 @@ defmodule Cloudex do
     Uploads a (list of) image file(s) and/or url(s) to cloudinary
   """
   @spec upload(list :: String.t) :: [Cloudex.UploadedImage.t]
-  @spec upload(list :: [String.t]) :: [Cloudex.UploadedImage.t]
-  def upload(list) do
+  @spec upload(list :: [String.t], %{tags: [String.t]}) :: [Cloudex.UploadedImage.t]
+  def upload(list, opts \\ %{}) do
     sanitized_list = list |> sanitize_list
 
     invalid_list = Enum.filter(sanitized_list, fn item -> match?({:error, _}, item) end)
     valid_list = Enum.filter(sanitized_list, fn item -> match?({:ok, _}, item) end)
     upload_results = valid_list
-      |> Enum.map(fn image -> Task.async(cloudinary_api, :upload, [image]) end)
+      |> Enum.map(fn image -> Task.async(cloudinary_api, :upload, [image, opts]) end)
       |> Enum.map(&Task.await(&1, 60_000))
     upload_results ++ invalid_list
   end

--- a/lib/cloudex/cloudinary_api/live.ex
+++ b/lib/cloudex/cloudinary_api/live.ex
@@ -8,12 +8,14 @@ defmodule Cloudex.CloudinaryApi.Live do
   alias Cloudex.UploadedImage
   alias Cloudex.Settings
 
+  def upload(item, opts \\ %{})
+
   @doc """
   Helper function to enable piping of {:ok, path} tuples into upload
   """
-  @spec upload({:ok, item :: String.t}) :: Cloudex.UploadedImage.t
-  def upload({:ok, item}) when is_binary(item) do
-    upload(item)
+  @spec upload({:ok, item :: String.t}, %{}) :: Cloudex.UploadedImage.t
+  def upload({:ok, item}, opts) when is_binary(item) do
+    upload(item, opts)
   end
 
   @doc """
@@ -22,7 +24,7 @@ defmodule Cloudex.CloudinaryApi.Live do
   or {:error, "reason"}
   """
   @spec upload(item :: String.t, opts :: map) :: Cloudex.UploadedImage.t
-  def upload(item, opts \\ %{})
+  def upload(item, opts)
   def upload(item, opts) when is_binary(item) do
     case item do
       "http://" <> _rest  -> item |> upload_url(opts)

--- a/lib/cloudex/cloudinary_api/test.ex
+++ b/lib/cloudex/cloudinary_api/test.ex
@@ -32,8 +32,10 @@ defmodule Cloudex.CloudinaryApi.Test do
 
   defp return_fake_response(opts) do
     public_id = Map.get(opts, :public_id, "i2nruesgu4om3w9mtk1z")
-    tags = Map.get(opts, :tags, "")
-      |> String.split(",")
+    tags = case Map.get(opts, :tags, []) do
+      list when is_list(list) -> list
+      s -> String.split(s, ",")
+    end
     {:ok, date} = Timex.local |> Timex.format("{ISO:Basic}")
     {:ok, %UploadedImage{
       bytes: 22659,

--- a/lib/cloudex/cloudinary_api/test.ex
+++ b/lib/cloudex/cloudinary_api/test.ex
@@ -11,8 +11,8 @@ defmodule Cloudex.CloudinaryApi.Test do
   @doc """
   Helper function to enable piping of {:ok, path} tuples into upload
   """
-  def upload({:ok, item}, _opts) when is_binary(item) do
-    upload(item)
+  def upload({:ok, item}, opts) when is_binary(item) do
+    upload(item, opts)
   end
 
 
@@ -32,6 +32,7 @@ defmodule Cloudex.CloudinaryApi.Test do
 
   defp return_fake_response(opts) do
     public_id = Map.get(opts, :public_id, "i2nruesgu4om3w9mtk1z")
+    tags = Map.get(opts, :tags, [])
     {:ok, date} = Timex.local |> Timex.format("{ISO:Basic}")
     {:ok, %UploadedImage{
       bytes: 22659,
@@ -45,7 +46,7 @@ defmodule Cloudex.CloudinaryApi.Test do
       secure_url: "https://d1vibqt9pdnk2f.cloudfront.net/image/upload/v1448618543/i2nruesgu4om3w9mtk1z.jpg",
       signature: "77b447746476c82bb4921fdea62a9227c584974b",
       source: "test.jpg",
-      tags: [],
+      tags: tags,
       type: "upload",
       url: "http://images.cloudinary.com/test/image/upload/v1448618543/i2nruesgu4om3w9mtk1z.jpg",
       version: 1448618543,

--- a/lib/cloudex/cloudinary_api/test.ex
+++ b/lib/cloudex/cloudinary_api/test.ex
@@ -32,7 +32,8 @@ defmodule Cloudex.CloudinaryApi.Test do
 
   defp return_fake_response(opts) do
     public_id = Map.get(opts, :public_id, "i2nruesgu4om3w9mtk1z")
-    tags = Map.get(opts, :tags, [])
+    tags = Map.get(opts, :tags, "")
+      |> String.split(",")
     {:ok, date} = Timex.local |> Timex.format("{ISO:Basic}")
     {:ok, %UploadedImage{
       bytes: 22659,

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -34,6 +34,6 @@ defmodule CloudexTest do
     tags = ["foo", "bar"]
     [
       {:ok, %Cloudex.UploadedImage{tags: ^tags}}
-    ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: tags})
+    ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: Enum.join(tags, ",")})
   end
 end

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -35,5 +35,9 @@ defmodule CloudexTest do
     [
       {:ok, %Cloudex.UploadedImage{tags: ^tags}}
     ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: Enum.join(tags, ",")})
+    # or simply
+    [
+      {:ok, %Cloudex.UploadedImage{tags: ^tags}}
+    ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: tags})
   end
 end

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -29,5 +29,11 @@ defmodule CloudexTest do
       {:error, "File nonexistent.png does not exist."}
     ] = Cloudex.upload(["./test/assets/test.jpg", "nonexistent.png", "http://example.org/images/cat.jpg"])
   end
-end
 
+  test "upload with tags" do
+    tags = ["foo", "bar"]
+    [
+      {:ok, %Cloudex.UploadedImage{tags: ^tags}}
+    ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: tags})
+  end
+end


### PR DESCRIPTION
API allows you to tag images during upload: http://cloudinary.com/documentation/upload_images#tagging_images

Correct way of setting multiple tags is to use comma. Ie. "tag1,tag2".