### PR TITLE
Delete Image Given a Public ID

### DIFF
--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -29,6 +29,14 @@ defmodule Cloudex do
     upload_results ++ invalid_list
   end
 
+  @doc """
+  Delete an image
+  """
+  def delete(item) do
+    Task.async(cloudinary_api, :delete, [item])
+    |> Task.await(60_000)
+  end
+
   defp sanitize_list(list, sanitized_list \\ [])
   defp sanitize_list(item, _sanitized_list) when is_binary(item) do
     [item] |> sanitize_list

--- a/lib/cloudex/cloudinary_api/live.ex
+++ b/lib/cloudex/cloudinary_api/live.ex
@@ -3,6 +3,8 @@ defmodule Cloudex.CloudinaryApi.Live do
   The live API implementation for Cloudinary uploading
   """
 
+  @base_url "https://api.cloudinary.com/v1_1/"
+  @cloudinary_headers [{"Content-Type", "application/x-www-form-urlencoded"}, {"Accept", "application/json"}]
   @behaviour Cloudex.CloudinaryApi
 
   alias Cloudex.UploadedImage
@@ -40,6 +42,23 @@ defmodule Cloudex.CloudinaryApi.Live do
     {:error, "Upload/1 only accepts a String or {:ok, String}, received: #{inspect invalid_item}"}
   end
 
+  @doc """
+  Deletes an image given a public id
+  """
+  def delete(item) when is_bitstring(item) do
+    case delete_file(item) do
+      {:ok, _} -> {:ok, %Cloudex.DeletedImage{public_id: item}}
+      {:error, response} -> {:error, response.body}
+    end
+  end
+
+  @doc """
+  Catches error when public id was invalid
+  """
+  def delete(invalid_item) do
+    {:error, "delete/1 only accepts valid public id, received: #{inspect invalid_item}"}
+  end
+
   defp upload_file(file_path, opts) do
     body = {:multipart, (opts |> prepare_opts |> sign |> unify |> Map.to_list) ++ [{:file, file_path}]}
     body |> post(file_path)
@@ -52,6 +71,12 @@ defmodule Cloudex.CloudinaryApi.Live do
       |> sign
       |> URI.encode_query
       |> post(url)
+  end
+
+  defp delete_file(item) do
+    options = [hackney: [basic_auth: {Settings.get(:api_key), Settings.get(:secret)}]]
+    url = "#{@base_url}#{Settings.get(:cloud_name)}/resources/image/upload?public_ids[]=#{item}"
+    HTTPoison.delete(url, @cloudinary_headers, options)
   end
 
   defp post(body, source) do

--- a/lib/cloudex/cloudinary_api/test.ex
+++ b/lib/cloudex/cloudinary_api/test.ex
@@ -24,6 +24,13 @@ defmodule Cloudex.CloudinaryApi.Test do
   end
 
   @doc """
+  Delete an image when passed in a public id
+  """
+  def delete(item) do
+    {:ok, %Cloudex.DeletedImage{public_id: item}}
+  end
+
+  @doc """
   Catches upload called without a string argument
   """
   def upload(invalid_item, _opts) do

--- a/lib/cloudex/deleted_image.ex
+++ b/lib/cloudex/deleted_image.ex
@@ -1,0 +1,3 @@
+defmodule Cloudex.DeletedImage do
+  defstruct public_id: nil
+end

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -40,4 +40,8 @@ defmodule CloudexTest do
       {:ok, %Cloudex.UploadedImage{tags: ^tags}}
     ] = Cloudex.upload(["./test/assets/test.jpg"], %{tags: tags})
   end
+
+  test "delete image with public id" do
+    assert {:ok, %Cloudex.DeletedImage{public_id: "public-id"}} = Cloudex.delete("public-id")
+  end
 end


### PR DESCRIPTION
Try to solve #12 

```elixir
[{:ok, image}] = Cloudex.upload("test/assets/multiple/12205032.jpg")
Cloudex.delete(image.public_id)
# => {:ok, %Cloudex.DeletedImage{public_id: "ysaixlehebdcusajobmt"}}
```

Not 100% sure about having just `delete` method. `delete_resource` could also be good since the API endpoint is actually called `delete_resource`.

Expanding this to have a list is also another possibility that could be done in this PR.

Let me know what I can do to improve my PR 😁