### PR TITLE
delete images given a list

### DIFF
--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -29,6 +29,10 @@ defmodule Cloudex do
     upload_results ++ invalid_list
   end
 
+  def delete(item_list) when is_list(item_list) do
+    Enum.map(item_list, fn item -> delete(item) end)
+  end
+
   @doc """
   Delete an image
   """

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -44,4 +44,11 @@ defmodule CloudexTest do
   test "delete image with public id" do
     assert {:ok, %Cloudex.DeletedImage{public_id: "public-id"}} = Cloudex.delete("public-id")
   end
+
+  test "delete images from a list of public id's" do
+    assert [
+      {:ok, %Cloudex.DeletedImage{public_id: "public-id-1"}},
+      {:ok, %Cloudex.DeletedImage{public_id: "public-id-2"}}
+    ] = Cloudex.delete(["public-id-1", "public-id-2"])
+  end
 end


### PR DESCRIPTION
Be able to delete images given a list with `delete/1`

```elixir
Cloudex.delete(["public-id-1", "public-id-2"])

# => 
[
  {:ok, %Cloudex.DeletedImage{public_id: "public-id-1"}},
  {:ok, %Cloudex.DeletedImage{public_id: "public-id-2"}}
]
```