### PR TITLE
fixed signing bug when appending secret

### DIFF
--- a/lib/cloudex/cloudinary_api/live.ex
+++ b/lib/cloudex/cloudinary_api/live.ex
@@ -116,14 +116,14 @@ defmodule Cloudex.CloudinaryApi.Live do
   defp sign(data) do
     timestamp = current_time()
 
-    data_to_sign = data
+    data_without_secret = data
       |> Map.delete(:file)
-      |> Map.merge(%{"timestamp" => (timestamp <> Settings.get(:secret))})
-
-    signature = data_to_sign
-      |> Enum.sort
+      |> Map.merge(%{"timestamp" => timestamp})
       |> Enum.map(fn {key, val} -> "#{key}=#{val}" end)
+      |> Enum.sort
       |> Enum.join("&")
+
+    signature = (data_without_secret <> Settings.get(:secret))
       |> sha
 
     Map.merge(data, %{


### PR DESCRIPTION
The current implementation of signing logic has a potential bug when uploading images with parameter keys lexically ordered after `timestamp` (eg. transformation, width, etc). Since the `secret` is always appended with the timestamp, there will be instances wherein the following string is generated right before creating the SHA1 checksum.

`folder=FOLDER_NAME&timestamp=124124SECRET&transformation=c_limit,w_1000`

This fix will make sure that the `secret` will always be appended at the end of the stringified parameters right before the hash is created.

Reference: http://cloudinary.com/documentation/upload_images#creating_api_authentication_signatures