### PR TITLE
Fix some dialyzer warnings; add type t to UploadedImage

### DIFF
--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -12,19 +12,23 @@ defmodule Cloudex do
   @spec start(settings :: map) :: {:ok, pid}
   defdelegate start(settings), to: Cloudex.Settings
 
+  @type upload_result :: {:ok, Cloudex.UploadedImage.t} | {:error, any}
+                       | [{:ok, Cloudex.UploadedImage.t} | {:error, any}]
+
   @doc ~S"""
     Uploads a (list of) image file(s) and/or url(s) to cloudinary
   """
-  @spec upload(list | String.t) :: [%Cloudex.UploadedImage{}]
-  @spec upload(list | [String.t], map) :: [%Cloudex.UploadedImage{}]
+  @spec upload(list | String.t) :: upload_result
+  @spec upload(list | [String.t], map) :: upload_result
   def upload(list, options \\ %{}) do
     sanitized_list = sanitize_list(list)
     invalid_list = Enum.filter(sanitized_list, &(match?({:error, _}, &1)))
     valid_list = Enum.filter(sanitized_list, &(match?({:ok, _}, &1)))
 
-    upload_results = valid_list
-                     |> Enum.map(&(Task.async(Cloudex.CloudinaryApi, :upload, [&1, options])))
-                     |> Enum.map(&Task.await(&1, 60_000))
+    upload_results =
+      valid_list
+      |> Enum.map(&(Task.async(Cloudex.CloudinaryApi, :upload, [&1, options])))
+      |> Enum.map(&Task.await(&1, 60_000))
 
     result = upload_results ++ invalid_list
 

--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -11,7 +11,7 @@ defmodule Cloudex.CloudinaryApi do
   returns {:ok, %UploadedFile{}} containing all the information from cloudinary
   or {:error, "reason"}
   """
-  @spec upload(String.t | {:ok, String.t}, map) :: {:ok, %Cloudex.UploadedImage{}} | {:error, any}
+  @spec upload(String.t | {:ok, String.t}, map) :: {:ok, Cloudex.UploadedImage.t} | {:error, any}
   def upload({:ok, item}, opts) when is_binary(item), do: upload(item, opts)
   def upload(item, opts)
   def upload(item, opts) when is_binary(item) do
@@ -72,7 +72,6 @@ defmodule Cloudex.CloudinaryApi do
     |> URI.encode_query
     |> post(url)
   end
-
 
   @spec delete_file(bitstring) :: {:ok, %Cloudex.DeletedImage{}} | {:error, %Elixir.HTTPoison.Error{}}
   defp delete_file(item) do
@@ -162,5 +161,4 @@ defmodule Cloudex.CloudinaryApi do
     |> round
     |> Integer.to_string
   end
-
 end

--- a/lib/cloudex/uploaded_image.ex
+++ b/lib/cloudex/uploaded_image.ex
@@ -19,6 +19,26 @@ defmodule Cloudex.UploadedImage do
   * secure_url
   * original_filename
   """
+
+  @type t :: %__MODULE__{
+          source: String.t | nil,
+          public_id: String.t | nil,
+          version: String.t | nil,
+          width: non_neg_integer | nil,
+          height: non_neg_integer | nil,
+          format: String.t | nil,
+          created_at: String.t | nil,
+          resource_type: String.t | nil,
+          tags: [String.t] | [] | nil,
+          bytes: non_neg_integer | nil,
+          type: String.t | nil,
+          etag: String.t | nil,
+          url: String.t | nil,
+          secure_url: String.t | nil,
+          signature: String.t | nil,
+          original_filename: String.t | nil
+        }
+
   defstruct source: nil,
             public_id: nil,
             version: nil,
@@ -35,5 +55,4 @@ defmodule Cloudex.UploadedImage do
             url: nil,
             secure_url: nil,
             original_filename: nil
-
 end


### PR DESCRIPTION
- Fixes some dialyzer errors
- Adds a `t` for documenting the `%Cloudex.UploadedImage{}` struct
- A tiny bit of formatting

Fixes #34 