### PR TITLE
[GNEE-856] Adding "context" to UploadedImage

### DIFF
--- a/fixture/vcr_cassettes/test_upload_with_context.json
+++ b/fixture/vcr_cassettes/test_upload_with_context.json
@@ -1,0 +1,34 @@
+[
+  {
+    "request": {
+      "body": "{:multipart, [{:file, \"./test/assets/test.jpg\"}, {\"api_key\", \"my_key\"}, {\"context\", \"{\\\"foo\\\":\\\"bar\\\"}\"}, {\"signature\", \"099cb9c54183eb5608bd5a0f40c701073e702e8d\"}, {\"timestamp\", \"1530872318\"}]}",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.cloudinary.com/v1_1/my_cloud_name/image/upload"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"error\":{\"message\":\"Unknown API key my_key\"}}",
+      "headers": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 06 Jul 2018 10:18:39 GMT",
+        "Server": "cloudinary",
+        "Status": "401 Unauthorized",
+        "X-Cld-Error": "Unknown API key my_key",
+        "X-Request-Id": "051e1a8eb19fec89",
+        "X-UA-Compatible": "IE=Edge,chrome=1",
+        "X-XSS-Protection": "1; mode=block",
+        "Content-Length": "46",
+        "Connection": "keep-alive"
+      },
+      "status_code": 401,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -115,9 +115,21 @@ defmodule Cloudex.CloudinaryApi do
          do: handle_response(response, source)
   end
 
+  defp context_to_list (context) do
+    Enum.reduce(context, [], fn {k, v}, acc ->  acc ++ ["#{k}=#{v}"] end)
+    |> Enum.join("|")
+  end
+
   @spec prepare_opts(map | list) :: map
+
+  defp prepare_opts(%{context: context, tags: tags} = opts) when is_list(tags),
+    do: %{opts | context: context_to_list(context), tags: Enum.join(tags, ",")}
+
   defp prepare_opts(%{tags: tags} = opts) when is_list(tags),
     do: %{opts | tags: Enum.join(tags, ",")}
+
+  defp prepare_opts(%{context: context} = opts) when is_map(context),
+    do: %{opts | context: context_to_list(context)}
 
   defp prepare_opts(opts), do: opts
 
@@ -145,7 +157,6 @@ defmodule Cloudex.CloudinaryApi do
   @spec sign(map) :: map
   defp sign(data) do
     timestamp = current_time()
-
     data_without_secret =
       data
       |> Map.delete(:file)

--- a/lib/cloudex/uploaded_image.ex
+++ b/lib/cloudex/uploaded_image.ex
@@ -39,7 +39,8 @@ defmodule Cloudex.UploadedImage do
           type: String.t() | nil,
           url: String.t() | nil,
           version: String.t() | nil,
-          width: non_neg_integer | nil
+          width: non_neg_integer | nil,
+          context: struct | nil
         }
 
   defstruct bytes: nil,
@@ -59,5 +60,6 @@ defmodule Cloudex.UploadedImage do
             type: nil,
             url: nil,
             version: nil,
-            width: nil
+            width: nil,
+            context: nil
 end

--- a/mix.lock
+++ b/mix.lock
@@ -24,7 +24,7 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.6.0", "5e206ed04860555a455de2983937efd3ce79f42bd8536fc6b900cc286f5bb830", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "timex": {:hex, :timex, "3.2.2", "f83c655ecb9472d4a614c3d27ce98483698ad81736647cba74425c33bcd3c7fb", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -79,6 +79,13 @@ defmodule CloudexTest do
     end
   end
 
+  test "upload with context" do
+    use_cassette "test_upload_with_context" do
+      {:ok, uploaded_image} = Cloudex.upload(["./test/assets/test.jpg"], %{context: %{foo: "bar"}})
+      assert uploaded_image.context != nil
+    end
+  end
+
   test "delete image with public id" do
     use_cassette "test_delete" do
       assert {:ok, %Cloudex.DeletedImage{public_id: "rurwrndtvgzfajljllnr"}} =


### PR DESCRIPTION
- Adding support for providing a custom `struct` as metadata.
- According to Cloudinary's API, the `context` field must be serialized as pipe-separated list - this PR does not cover escaping `|` and `=` though.

See also:
- https://support.cloudinary.com/hc/en-us/articles/202521142-Can-I-add-metadata-to-images-
- https://support.cloudinary.com/hc/en-us/articles/202521142-Can-I-add-metadata-to-images-