### PR TITLE
Remove `resource_type` IAW documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+
+/.elixir_ls

--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -177,7 +177,7 @@ defmodule Cloudex.CloudinaryApi do
     timestamp = current_time()
     data_without_secret =
       data
-      |> Map.delete(:file)
+      |> Map.drop([:file, :resource_type])
       |> Map.merge(%{"timestamp" => timestamp})
       |> Enum.map(fn {key, val} -> "#{key}=#{val}" end)
       |> Enum.sort()


### PR DESCRIPTION
This change drops the `resource_type` value from the attributes being signed.

Resolves #50