### PR TITLE
Allow S3 paths to be passed to Cloudinary when using a private bucket

### DIFF
--- a/fixture/vcr_cassettes/test_upload_url_with_s3.json
+++ b/fixture/vcr_cassettes/test_upload_url_with_s3.json
@@ -1,0 +1,39 @@
+[
+  {
+    "request": {
+      "body": "file=s3://my-bucket/folder/test_image.jpg",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json"
+      },
+      "method": "post",
+      "options": {
+        "basic_auth": [
+          "my_key",
+          "my_secret"
+        ]
+      },
+      "request_body": "",
+      "url": "https://api.cloudinary.com/v1_1/my_cloud_name/image/upload"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"public_id\":\"b0b6ougwokm8v8d1rx98\",\"version\":1535339744,\"signature\":\"d0bd48c7095835ce37d607ff25098193705496f7\",\"width\":2848,\"height\":4288,\"format\":\"jpg\",\"resource_type\":\"image\",\"created_at\":\"2018-08-27T03:15:44Z\",\"tags\":[],\"bytes\":4520895,\"type\":\"upload\",\"etag\":\"22ac1427fa960ef88e1572ad81e5640e\",\"placeholder\":false,\"url\":\"http://res.cloudinary.com/my_cloud_name/image/upload/v1535339744/b0b6ougwokm8v8d1rx98.jpg\",\"secure_url\":\"https://res.cloudinary.com/my_cloud_name/image/upload/v1535339744/b0b6ougwokm8v8d1rx98.jpg\",\"original_filename\":\"test_image\"}",
+      "headers": {
+        "Cache-Control": "max-age=0, private, must-revalidate",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 27 Aug 2018 03:15:45 GMT",
+        "ETag": "\"c670544be4642c2d94d82c51ac393fc1\"",
+        "Server": "cloudinary",
+        "Status": "200 OK",
+        "X-Request-Id": "8c5ee5372fa3779b",
+        "X-UA-Compatible": "IE=Edge,chrome=1",
+        "X-XSS-Protection": "1; mode=block",
+        "transfer-encoding": "chunked",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -71,7 +71,7 @@ defmodule Cloudex do
 
   defp sanitize_list([item | tail], sanitized_list) do
     result =
-      if Regex.match?(~r/^http/, item), do: {:ok, item}, else: handle_file_or_directory(item)
+      if Regex.match?(~r/^(http|s3)/, item), do: {:ok, item}, else: handle_file_or_directory(item)
 
     new_list = [result | sanitized_list]
     sanitize_list(tail, new_list)

--- a/lib/cloudex/settings.ex
+++ b/lib/cloudex/settings.ex
@@ -6,7 +6,7 @@ defmodule Cloudex.Settings do
 
   use GenServer
 
-  @doc"""
+  @doc """
   Required by GenServer
   """
   def init(args) do

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -24,7 +24,8 @@ defmodule CloudexTest do
 
   test "upload single video file" do
     use_cassette "test_upload_video" do
-      assert {:ok, %Cloudex.UploadedImage{}} = Cloudex.upload("test/assets/teamwork.mp4", %{resource_type: "video"})
+      assert {:ok, %Cloudex.UploadedImage{}} =
+               Cloudex.upload("test/assets/teamwork.mp4", %{resource_type: "video"})
     end
   end
 
@@ -49,6 +50,13 @@ defmodule CloudexTest do
                Cloudex.upload(
                  "https://cdn.mhpbooks.com/uploads/2014/10/shutterstock_172896005.jpg"
                )
+    end
+  end
+
+  test "upload s3 image url" do
+    use_cassette "test_upload_url with s3" do
+      assert {:ok, %Cloudex.UploadedImage{}} =
+               Cloudex.upload("s3://my-bucket/folder/test_image.jpg")
     end
   end
 
@@ -89,7 +97,9 @@ defmodule CloudexTest do
 
   test "upload with context" do
     use_cassette "test_upload_with_context" do
-      {:ok, uploaded_image} = Cloudex.upload(["./test/assets/test.jpg"], %{context: %{foo: "bar"}})
+      {:ok, uploaded_image} =
+        Cloudex.upload(["./test/assets/test.jpg"], %{context: %{foo: "bar"}})
+
       assert uploaded_image.context != nil
     end
   end
@@ -119,8 +129,7 @@ defmodule CloudexTest do
 
   test "delete images for a prefix" do
     use_cassette "test_delete_prefix" do
-      assert {:ok, "some_prefix"} =
-        Cloudex.delete_prefix("some_prefix")
+      assert {:ok, "some_prefix"} = Cloudex.delete_prefix("some_prefix")
     end
   end
 


### PR DESCRIPTION
And apply `mix format`. 

This one stumped me for a bit until I realized it seemed like the Cloudinary API was returning too quickly.  :)

I'm using a private bucket with signed URLs to allow the client to upload images, then have Cloudinary transfer them via S3 URL and a bucket policy.  

Reference: https://cloudinary.com/documentation/upload_images

Thanks for the great lib!