### PR TITLE
create new UploadedVideo struct

### DIFF
--- a/lib/cloudex/uploaded_video.ex
+++ b/lib/cloudex/uploaded_video.ex
@@ -1,0 +1,80 @@
+defmodule Cloudex.UploadedVideo do
+  @moduledoc """
+  A simple struct containing all the information from cloudinary.
+
+  * source
+  * public_id
+  * version
+  * signature
+  * width
+  * hieght
+  * format
+  * resource_type
+  * created_at
+  * tags
+  * bytes
+  * type
+  * etag
+  * url
+  * secure_url
+  * original_filename
+  * phash
+  * audio
+  * video
+  * frame_rate
+  * bit_rate
+  * duration
+  """
+
+  @type t :: %__MODULE__{
+          audio: map() | %{},
+          bit_rate: non_neg_integer | nil,
+          bytes: non_neg_integer | nil,
+          created_at: String.t() | nil,
+          duration: float() | nil,
+          etag: String.t() | nil,
+          format: String.t() | nil,
+          frame_rate: String.t() | nil,
+          height: non_neg_integer | nil,
+          moderation: [String.t()] | [] | nil,
+          original_filename: String.t() | nil,
+          phash: String.t() | nil,
+          public_id: String.t() | nil,
+          resource_type: String.t() | nil,
+          secure_url: String.t() | nil,
+          signature: String.t() | nil,
+          source: String.t() | nil,
+          tags: [String.t()] | [] | nil,
+          type: String.t() | nil,
+          url: String.t() | nil,
+          version: String.t() | nil,
+          video: map() | %{},
+          width: non_neg_integer | nil,
+          context: struct | nil
+        }
+
+  defstruct audio: %{},
+            bit_rate: nil,
+            bytes: nil,
+            created_at: nil,
+            duration: nil,
+            etag: nil,
+            format: nil,
+            frame_rate: nil,
+            height: nil,
+            moderation: nil,
+            original_filename: nil,
+            phash: nil,
+            public_id: nil,
+            resource_type: nil,
+            secure_url: nil,
+            signature: nil,
+            source: nil,
+            tags: nil,
+            type: nil,
+            url: nil,
+            version: nil,
+            video: %{},
+            width: nil,
+            context: nil
+end

--- a/test/cloudex/cloudex_test.exs
+++ b/test/cloudex/cloudex_test.exs
@@ -24,8 +24,41 @@ defmodule CloudexTest do
 
   test "upload single video file" do
     use_cassette "test_upload_video" do
-      assert {:ok, %Cloudex.UploadedImage{}} =
-               Cloudex.upload("test/assets/teamwork.mp4", %{resource_type: "video"})
+      result = Cloudex.upload("test/assets/teamwork.mp4", %{resource_type: "video"})
+
+      assert {:ok,
+              %Cloudex.UploadedVideo{
+                audio: %{},
+                bit_rate: 27217,
+                bytes: 299_396,
+                created_at: "2018-08-27T03:15:42Z",
+                duration: 88.0,
+                etag: "aaf7d25e2f37927b2be50e20c58304e3",
+                format: "mp4",
+                frame_rate: 25.0,
+                height: 400,
+                original_filename: "teamwork",
+                public_id: "bqzkffnaviwjafajqraf",
+                resource_type: "video",
+                secure_url:
+                  "https://res.cloudinary.com/my_cloud_name/video/upload/v1535339742/bqzkffnaviwjafajqraf.mp4",
+                signature: "5b477564193de869ad6cf84e561dd74a091a2211",
+                source: "test/assets/teamwork.mp4",
+                tags: [],
+                type: "upload",
+                url:
+                  "http://res.cloudinary.com/my_cloud_name/video/upload/v1535339742/bqzkffnaviwjafajqraf.mp4",
+                version: 1_535_339_742,
+                video: %{
+                  "bit_rate" => "26340",
+                  "codec" => "h264",
+                  "dar" => "8:5",
+                  "level" => 31,
+                  "pix_format" => "yuv420p",
+                  "profile" => "Constrained Baseline"
+                },
+                width: 640
+              }} = result
     end
   end
 


### PR DESCRIPTION
Currently, for video uploads, the `Cloudex.upload()` function returns a `%Cloudex.UploadedImage` struct which is missing some of the metadata fields from the video upload response in cloudinary https://cloudinary.com/documentation/upload_videos#video_upload_response . I wanted to open this PR to start a discussion on whether this would be an appropriate solution without breaking any backward compatibility. 