### PR TITLE
Extend hackney timeout from the default of 5 seconds to 60 seconds

### DIFF
--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -116,7 +116,9 @@ defmodule Cloudex.CloudinaryApi do
   defp credentials do
     [
       hackney: [
-        basic_auth: {Cloudex.Settings.get(:api_key), Cloudex.Settings.get(:secret)}
+        basic_auth: {Cloudex.Settings.get(:api_key), Cloudex.Settings.get(:secret)},
+        timeout: 60_000,
+        recv_timeout: 60_000
       ]
     ]
   end


### PR DESCRIPTION
Fixes #71 .

This also matches the duration of the `Task.await` calls throughout the library