### PR TITLE
Update typespec for `Cloudex.upload/2`

### DIFF
--- a/lib/cloudex.ex
+++ b/lib/cloudex.ex
@@ -12,16 +12,13 @@ defmodule Cloudex do
   @spec start(settings :: map) :: {:ok, pid}
   defdelegate start(settings), to: Cloudex.Settings
 
-  @type upload_result ::
-          {:ok, Cloudex.UploadedImage.t()}
-          | {:error, any}
-          | [{:ok, Cloudex.UploadedImage.t()} | {:error, any}]
+  @type upload_result :: {:ok, Cloudex.UploadedImage.t()} | {:error, any}
 
   @doc ~S"""
     Uploads a (list of) image file(s) and/or url(s) to cloudinary
   """
-  @spec upload(list | String.t()) :: upload_result
-  @spec upload(list | [String.t()], map) :: upload_result
+  @spec upload(list | String.t(), map) :: upload_result
+  @spec upload(list | [String.t()], map) :: [upload_result]
   def upload(list, options \\ %{}) do
     sanitized_list = sanitize_list(list)
     invalid_list = Enum.filter(sanitized_list, &match?({:error, _}, &1))


### PR DESCRIPTION
When passing in a single string, it can only ever return a single result. A list of strings will return a list of results.